### PR TITLE
modification hosting url for mailer to dev heroku env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,5 +95,5 @@ Rails.application.configure do
   #Mailer
   config.action_mailer.delivery_method = :mailjet
   config.action_mailer.default :charset => "utf-8"
-  config.action_mailer.default_url_options = { :host => 'projet-final-thp-rennesprod.herokuapp.com/' }
+  config.action_mailer.default_url_options = { :host => 'projet-final-thp-rennes-dev.herokuapp.com/' }
 end


### PR DESCRIPTION
Modification from: 
config.action_mailer.default_url_options = { :host => 'projet-final-thp-rennesprod.herokuapp.com/' }
to
config.action_mailer.default_url_options = { :host => 'projet-final-thp-rennes-dev.herokuapp.com/' }